### PR TITLE
swift-account-audit fixed

### DIFF
--- a/bin/swift-account-audit
+++ b/bin/swift-account-audit
@@ -319,7 +319,7 @@ class Auditor(object):
         if self.account_exceptions:
             print "        Exceptions: %d" % self.account_exceptions
         if self.account_container_mismatch:
-            print " Cntainer mismatch: %d" % self.account_container_mismatch
+            print " Container mismatch: %d" % self.account_container_mismatch
         if self.account_object_mismatch:
             print "   Object mismatch: %d" % self.account_object_mismatch
         print


### PR DESCRIPTION
does anyone use it?

```
$ swift-account-audit SOSO_88ad0b83-b2c5-4fa1-b2d6-60c597202076
Traceback (most recent call last):
  File "/usr/local/bin/swift-account-audit", line 5, in <module>
    pkg_resources.run_script('swift==1.7.0', 'swift-account-audit')
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 499, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 1235, in run_script
    execfile(script_filename, namespace, namespace)
  File "/usr/local/lib/python2.7/dist-packages/swift-1.7.0-py2.7.egg/EGG-INFO/scripts/swift-account-audit", line 362, in <module>
    auditor = Auditor(**options)
  File "/usr/local/lib/python2.7/dist-packages/swift-1.7.0-py2.7.egg/EGG-INFO/scripts/swift-account-audit", line 58, in __init__
    self.object_ring = Ring(os.path.join(swift_dir, ring_name='object'))
TypeError: join() got an unexpected keyword argument 'ring_name'
```
