### PR TITLE
Added bakthat as an associated project.

### DIFF
--- a/doc/source/associated_projects.rst
+++ b/doc/source/associated_projects.rst
@@ -34,6 +34,7 @@ Command Line Access
 -------------------
 
 * `Swiftly <https://github.com/gholt/swiftly>`_ - Alternate command line access to Swift with direct (no proxy) access capabilities as well.
+* `Bakthat <https://github.com/tsileo/bakthat>`_ - Backup framework and command line tool.
 
 
 Log Processing


### PR DESCRIPTION
I just added OpenStack Swift support to [bakthat](http://docs.bakthat.io), I think it can be interesting for Swift users.

I know that pull requests submitted through GitHub will be ignored, just to let you know about bakthat.
