### PR TITLE
Hash the incoming key.

### DIFF
--- a/swift/common/memcached.py
+++ b/swift/common/memcached.py
@@ -146,7 +146,7 @@ class MemcacheRing(object):
         Retrieves a server conn from the pool, or connects a new one.
         Chooses the server based on a consistent hash of "key".
         """
-        pos = bisect(self._sorted, key)
+        pos = bisect(self._sorted, md5hash(key))
         served = []
         while len(served) < self._tries:
             pos = (pos + 1) % len(self._sorted)


### PR DESCRIPTION
This patch adds the hashing of the incoming key to ensure it is in the same namespace as the consistent hash "ring".  Otherwise, keys above the namespace all map to the first server in the _sorted.

Alternately, I can provide a patch that documents the requirement that the passed in "key" already be hashed -- perhaps by changing the argument name from "key" to "key_hash"?
