### PR TITLE
Speeding up the proxy

### DIFF
--- a/swift/proxy/controllers/obj.py
+++ b/swift/proxy/controllers/obj.py
@@ -1099,7 +1099,7 @@ class ObjectController(Controller):
             for conn in conns:
                 if not conn in conn_good_status:
                     try:
-                        with Timeout(self.app.node_timeout_split):
+                        with Timeout(self.app.node_timeout_slice):
                             if conn.resp:
                                 response = conn.resp
                             else:
@@ -1119,7 +1119,7 @@ class ObjectController(Controller):
                                 etags.add(response.getheader('etag').strip('"'))
                                 conn_good_status.append(conn)
                     except (Exception, Timeout):
-                        conn_timeout_increaser += self.app.node_timeout_piece
+                        conn_timeout_increaser += self.app.node_timeout_slice
                         if conn_timeout_increaser >= self.app.node_timeout:
                             statuses.append(HTTP_SERVICE_UNAVAILABLE)
                             self.exception_occurred(

--- a/swift/proxy/server.py
+++ b/swift/proxy/server.py
@@ -59,7 +59,7 @@ class Application(object):
 
         swift_dir = conf.get('swift_dir', '/etc/swift')
         self.rate_put_replicas = float(conf.get('rate_put_replicas', 0.5))
-        self.node_timeout_piece = float(conf.get('node_timeout_piece', 0.01))
+        self.node_timeout_slice = float(conf.get('node_timeout_slice', 0.01))
         self.node_timeout = int(conf.get('node_timeout', 10))
         self.conn_timeout = float(conf.get('conn_timeout', 0.5))
         self.client_timeout = int(conf.get('client_timeout', 60))


### PR DESCRIPTION
The code changed will speeding up the proxy while handling the request of PUT.
We can ensure the final status of PUT request after half of the connects return successful status.It does not need to wait all of the connects return response. 
