### PR TITLE
Filter the devs when rebalance for the first time 

### DIFF
--- a/swift/common/ring/builder.py
+++ b/swift/common/ring/builder.py
@@ -337,6 +337,13 @@ class RingBuilder(object):
 
         self._ring = None
         if self._last_part_moves_epoch is None:
+            weighted_devs = []
+            for v in self.devs:
+                if v and v['weight'] == 0:
+                    weighted_devs.append(None)
+                else:
+                    weighted_devs.append(v)
+            self.devs = weighted_devs
             self._initial_balance()
             self.devs_changed = False
             return self.parts, self.get_balance()


### PR DESCRIPTION
Here is my procedure:
Step 1: build it
# swift-ring-builder account.builder create 18 3 0
# export HOST_IP=127.0.0.1
# swift-ring-builder account.builder add z1-${HOST_IP}:9023/sdb1 100
# swift-ring-builder account.builder add z2-${HOST_IP}:9023/sdb2 100
# swift-ring-builder account.builder add z3-${HOST_IP}:9023/sdb3 100

Step 2: check it.
# swift-ring-builder account.builder

account.builder, build version 3
262144 partitions, 3 replicas, 3 zones, 3 devices, 100.00 balance
The minimum number of hours before a partition can be reassigned is 0
Devices:    id  zone      ip address  port      name weight partitions balance meta
             0     1       127.0.0.1  9023      sdb1 100.00          0 -100.00 
             1     2       127.0.0.1  9023      sdb2 100.00          0 -100.00 
             2     3       127.0.0.1  9023      sdb3 100.00          0 -100.00

Step 3: remove one dev
# swift-ring-builder account.builder remove d0

Step 4: generate
# swift-ring-builder account.builder rebalance

Step 5: check it again
# swift-ring-builder account.builder

account.builder, build version 4
262144 partitions, 3 replicas, 2 zones, 2 devices, 0.00 balance
The minimum number of hours before a partition can be reassigned is 0
Devices:    id  zone      ip address  port      name weight partitions balance meta
             1     2       127.0.0.1  9023      sdb2 100.00     393216    0.00 
             2     3       127.0.0.1  9023      sdb3 100.00     393216    0.00

This result is my expection. But currently with builer.py under master branch, the last result would be:

account.builder, build version 4
262144 partitions, 3 replicas, 3 zones, 3 devices, 0.00 balance
The minimum number of hours before a partition can be reassigned is 0
Devices:    id  zone      ip address  port      name weight partitions balance meta
             0     1       127.0.0.1  9023      sdb1   0.00          0    0.00 
             1     2       127.0.0.1  9023      sdb2 100.00     393216    0.00 
             2     3       127.0.0.1  9023      sdb3 100.00     393216    0.00

So, the difference is legible. And my question is why the dev with zero weight and partitions still appear in the builder file, which would lead to an exception "Device 0 already uses ..." when add the dev 0 next time.

PS: I'm new to github and excited and a little bit apprehensive to pull my own request. Tx!
