### PR TITLE
fixed typo in proxy-server.conf.5 manpage

### DIFF
--- a/doc/manpages/proxy-server.conf.5
+++ b/doc/manpages/proxy-server.conf.5
@@ -519,7 +519,7 @@ Chunk size to read from object servers. The default is 8192.
 Chunk size to read from clients. The default is 8192.
 .IP \fBnode_timeout\fR
 Request timeout to external services. The default is 10 seconds.
-.IP \fBclient_timeoutt\fR
+.IP \fBclient_timeout\fR
 Timeout to read one chunk from a client. The default is 60 seconds.
 .IP \fBconn_timeout\fR
 Connection timeout to external services. The default is 0.5 seconds.


### PR DESCRIPTION
this is only a tiny fix of a typo in a manpage
