### PR TITLE
reduce info-level logging

### DIFF
--- a/swift/obj/auditor.py
+++ b/swift/obj/auditor.py
@@ -64,7 +64,7 @@ class AuditorWorker(object):
             [(s, 0) for s in self.stats_sizes + ['OVER']])
 
     def audit_all_objects(self, mode='once'):
-        self.logger.info(_('Begin object audit "%s" mode (%s)') %
+        self.logger.debug(_('Begin object audit "%s" mode (%s)') %
                          (mode, self.auditor_type))
         begin = reported = time.time()
         self.total_bytes_processed = 0
@@ -119,7 +119,7 @@ class AuditorWorker(object):
             time_auditing += (now - loop_time)
         # Avoid divide by zero during very short runs
         elapsed = (time.time() - begin) or 0.000001
-        self.logger.info(_(
+        self.logger.debug(_(
             'Object audit (%(type)s) "%(mode)s" mode '
             'completed: %(elapsed).02fs. Total quarantined: %(quars)d, '
             'Total errors: %(errors)d, Total files/sec: %(frate).2f , '

--- a/swift/obj/replicator.py
+++ b/swift/obj/replicator.py
@@ -343,7 +343,7 @@ class ObjectReplicator(Daemon):
                      'med': self.partition_times[
                          len(self.partition_times) // 2]})
         else:
-            self.logger.info(
+            self.logger.debug(
                 _("Nothing replicated for %s seconds."),
                 (time.time() - self.start))
 
@@ -500,11 +500,11 @@ class ObjectReplicator(Daemon):
         # Run the replicator continually
         while True:
             start = time.time()
-            self.logger.info(_("Starting object replication pass."))
+            self.logger.debug(_("Starting object replication pass."))
             # Run the replicator
             self.replicate()
             total = (time.time() - start) / 60
-            self.logger.info(
+            self.logger.debug(
                 _("Object replication complete. (%.02f minutes)"), total)
             dump_recon_cache({'object_replication_time': total,
                               'object_replication_last': time.time()},


### PR DESCRIPTION
There's too much of info level logging in syslog and the log files grows too fast even if nothing wrong is happening.

Actually, it might be good to change the log level of other messages (repeating after 1 minute by default) as well.

SUSE bugzilla reference: https://bugzilla.novell.com/show_bug.cgi?id=838643
