### PR TITLE
Update swift-drive-audit

### DIFF
--- a/bin/swift-drive-audit
+++ b/bin/swift-drive-audit
@@ -79,7 +79,7 @@ def get_errors(error_re, log_file_pattern, minutes, logger):
     # track of the year and month in case the year recently
     # ticked over
     year = now_time.year
-    prev_entry_month = now_time.month
+    prev_entry_month = now_time.strftime('%b')
     errors = {}
 
     reached_old_logs = False


### PR DESCRIPTION
处理跨年日期时存在错误，prev_entry_month应该是'Jan',但now_time.month返回的却是整数1.