### PR TITLE
Fix high CPU usage in bad network environment

### DIFF
--- a/swift/common/middleware/recon.py
+++ b/swift/common/middleware/recon.py
@@ -61,6 +61,7 @@ class ReconMiddleware(object):
             if f.startswith('object') and f.endswith('ring.gz'):
                 self.rings.append(os.path.join(swift_dir, f))
         self.mount_check = config_true_value(conf.get('mount_check', 'true'))
+        self.page_size = getpagesize()
 
     def _from_recon_cache(self, cache_keys, cache_file, openr=open):
         """retrieve values from a recon cache file
@@ -307,7 +308,7 @@ class ReconMiddleware(object):
                         sockstat['orphan'] = int(tcpstats[4])
                         sockstat['time_wait'] = int(tcpstats[6])
                         sockstat['tcp_mem_allocated_bytes'] = \
-                            int(tcpstats[10]) * getpagesize()
+                            int(tcpstats[10]) * self.page_size
         except IOError as e:
             if e.errno != errno.ENOENT:
                 raise


### PR DESCRIPTION
The method 'getpagesize' internally calls the method 'getrusage'. When
network is bad, connections are unstable, and then 'get_socket_info'
interface that in 'recon' middleware will be frequently triggerred. The
actual profile result (using strace) said that 'getrusage' calls are the
culprits. When using 'getrusage' to get fixed page
size(http://en.wikipedia.org/wiki/Page_(computer_memory)#Huge_pages), it
will fetch many useless information that do lead to high CPU usage (like
CPU usage, memory usage, context switches, swaps and etc), so I think it
is unnecessary to call it everytime.