### PR TITLE
The spec of Content-Disposition does not require a space character af…

### DIFF
--- a/swift/common/utils.py
+++ b/swift/common/utils.py
@@ -3355,8 +3355,8 @@ def parse_content_disposition(header):
     """
     attributes = {}
     attrs = ''
-    if '; ' in header:
-        header, attrs = header.split('; ', 1)
+    if ';' in header:
+        header, attrs = [x.strip() for x in header.split(';', 1)]
     m = True
     while m:
         m = ATTRIBUTES_RE.match(attrs)

--- a/test/unit/common/test_utils.py
+++ b/test/unit/common/test_utils.py
@@ -4629,6 +4629,12 @@ class TestParseContentDisposition(unittest.TestCase):
         self.assertEquals(name, 'form-data')
         self.assertEquals(attrs, {'name': 'somefile', 'filename': 'test.html'})
 
+    def test_content_disposition_without_white_space(self):
+        name, attrs = utils.parse_content_disposition(
+            'form-data;name="somefile";filename="test.html"')
+        self.assertEquals(name, 'form-data')
+        self.assertEquals(attrs, {'name': 'somefile', 'filename': 'test.html'})
+
 
 class TestIterMultipartMimeDocuments(unittest.TestCase):
 


### PR DESCRIPTION
The spec of Content-Disposition does not require a space character after comma: http://www.ietf.org/rfc/rfc2183.txt