### PR TITLE
Fix"swift-get-nodes ValueError on non-legacy rings"

### DIFF
--- a/bin/swift-get-nodes
+++ b/bin/swift-get-nodes
@@ -59,7 +59,7 @@ if __name__ == '__main__':
 
     ring = ring_name = None
     if ring_path:
-        ring_name = basename(ring_path)[:len('ring.gz')]
+        ring_name = basename(ring_path)[:-len('.ring.gz')]
         ring = Ring(ring_path)
 
     try:


### PR DESCRIPTION
swift-get-nodes ValueError on non-legacy rings
more, https://bugs.launchpad.net/swift/+bug/1668736