### PR TITLE
support rsync with password

### DIFF
--- a/etc/account-server.conf-sample
+++ b/etc/account-server.conf-sample
@@ -189,6 +189,16 @@ use = egg:swift#recon
 # long-term use.
 #
 # handoffs_only = no
+# 
+# Support rsync to work with password. This option must work with the 
+# auth users and secrets file options opened in rsyncd.conf. Meanwhile,
+# the rsync_password option in container-replicator and object-replicator
+# should be enabled. You can set the rsync_password_file option to change
+# the default path of password file, which only contains the password for
+# the urser of rsync, as shown in the rsyncd-client.passwd-sample.
+# 
+# rsync_password = true
+# rsync_password_file = /etc/swift/rsyncd-client.passwd
 
 [account-auditor]
 # You can override the default log routing for this app here (don't use set!):

--- a/etc/container-server.conf-sample
+++ b/etc/container-server.conf-sample
@@ -202,6 +202,16 @@ use = egg:swift#recon
 # long-term use.
 #
 # handoffs_only = no
+#
+# Support rsync to work with password. This option must work with the 
+# auth users and secrets file options opened in rsyncd.conf. Meanwhile,
+# the rsync_password option in account-replicator and object-replicator
+# should be enabled. You can set the rsync_password_file option to change
+# the default path of password file, which only contains the password for
+# the urser of rsync, as shown in the rsyncd-client.passwd-sample.
+# 
+# rsync_password = true
+# rsync_password_file = /etc/swift/rsyncd-client.passwd
 
 [container-updater]
 # You can override the default log routing for this app here (don't use set!):

--- a/etc/object-server.conf-sample
+++ b/etc/object-server.conf-sample
@@ -305,6 +305,16 @@ use = egg:swift#recon
 # Work only with ionice_class.
 # ionice_class =
 # ionice_priority =
+#
+# Support rsync to work with password. This option must work with the 
+# auth users and secrets file options opened in rsyncd.conf. Meanwhile,
+# the rsync_password option in account-replicator and container-replicator
+# should be enabled. You can set the rsync_password_file option to change
+# the default path of password file, which only contains the password for
+# the urser of rsync, as shown in the rsyncd-client.passwd-sample.
+# 
+# rsync_password = true
+# rsync_password_file = /etc/swift/rsyncd-client.passwd
 
 [object-reconstructor]
 # You can override the default log routing for this app here (don't use set!):

--- a/etc/rsyncd-client.passwd-sample
+++ b/etc/rsyncd-client.passwd-sample
@@ -1,0 +1,1 @@
+password

--- a/etc/rsyncd.conf-sample
+++ b/etc/rsyncd.conf-sample
@@ -3,6 +3,19 @@ gid = swift
 log file = /var/log/rsyncd.log
 pid file = /var/run/rsyncd.pid
 
+# Support rsync to work with password. This option must work with the 
+# rsync_password option enabled in account-replicator, container-replicator
+# and object-replicator. You can set the secrets file option to change the
+# default password file, which contains the auth users and it's password,
+# as shown in the rsyncd.passwd-sample.
+#
+# Ensure the owner of the password file and the user who starts the
+# rsync are the same and change this file's permissions by using the chmod 
+# 600 command.
+#
+# auth users = rsync_user
+# secrets file = /etc/swift/rsyncd.passwd
+
 [account]
 max connections = 2
 path = /srv/node

--- a/etc/rsyncd.passwd-sample
+++ b/etc/rsyncd.passwd-sample
@@ -1,0 +1,1 @@
+rsync_user:password

--- a/swift/common/db_replicator.py
+++ b/swift/common/db_replicator.py
@@ -224,6 +224,9 @@ class Replicator(Daemon):
         self.extract_device_re = re.compile('%s%s([^%s]+)' % (
             self.root, os.path.sep, os.path.sep))
         self.handoffs_only = config_true_value(conf.get('handoffs_only', 'no'))
+        self.rsync_password = \
+            config_true_value(conf.get('rsync_password', 'no'))
+        self.rsync_password_file = conf.get('rsync_password_file', '/etc/swift/rsyncd-client.passwd')
 
     def _zero_stats(self):
         """Zero out the stats."""
@@ -279,6 +282,9 @@ class Replicator(Daemon):
         popen_args = ['rsync', '--quiet', '--no-motd',
                       '--timeout=%s' % int(math.ceil(self.node_timeout)),
                       '--contimeout=%s' % int(math.ceil(self.conn_timeout))]
+        if self.rsync_password:
+            passwd_opt = '--password-file=' + self.rsync_password_file
+            popen_args.append(passwd_opt)
         if whole_file:
             popen_args.append('--whole-file')
 

--- a/swift/obj/replicator.py
+++ b/swift/obj/replicator.py
@@ -187,6 +187,9 @@ class ObjectReplicator(Daemon):
         self.is_multiprocess_worker = None
         self._df_router = DiskFileRouter(conf, self.logger)
         self._child_process_reaper_queue = queue.LightQueue()
+        self.rsync_password = \
+            config_true_value(conf.get('rsync_password', 'no'))
+        self.rsync_password_file = conf.get('rsync_password_file', '/etc/swift/rsyncd-client.passwd')
 
     def _zero_stats(self):
         self.stats_for_dev = defaultdict(Stats)
@@ -435,6 +438,9 @@ class ObjectReplicator(Daemon):
             '--bwlimit=%s' % self.rsync_bwlimit,
             '--exclude=.*.%s' % ''.join('[0-9a-zA-Z]' for i in range(6))
         ]
+        if self.rsync_password:
+            passwd_opt = '--password-file=' + self.rsync_password_file
+            popen_args.append(passwd_opt)
         if self.rsync_compress and \
                 job['region'] != node['region']:
             # Allow for compression, but only if the remote node is in


### PR DESCRIPTION
As default, we use rsync with no password. While, in this situation, other server in our cluster can get information of these swift servers by rsync, which is unsafe.
For safety, if you need the rsync works with authorization, start  the rsync with the secrets file opened and enable the rsync_password  option in account-replicator, container-replicator and object-replicator.  Also, you can change the default password file for rsync(secrets file  option in rsyncd.conf) and swift(rsync_password_file option in account-  replicator, contain-replicator and object-replicator).  It must be noted that, the password file for rsync contains  username:password, while the password file for swift only contains the  password, as shown in the samples of password file.