### PR TITLE
Make object-expirer respect internal_client_conf_path

### DIFF
--- a/swift/obj/expirer.py
+++ b/swift/obj/expirer.py
@@ -186,7 +186,7 @@ class ObjectExpirer(Daemon):
         self.delay_reaping_times = read_conf_for_delay_reaping_times(conf)
 
     def _make_internal_client(self, is_legacy_conf):
-        if is_legacy_conf:
+        if is_legacy_conf and 'internal_client_conf_path' not in self.conf:
             ic_conf_path = self.conf_path
         else:
             ic_conf_path = \


### PR DESCRIPTION
When the object-expirer decides it was loaded from a "legacy_conf" it won't respect the internal_client_conf_path.

Change-Id: I24ec702cd2ed074ca9df084cefc896418cece394